### PR TITLE
[Fix] Requires One Of, Help Command Page Display

### DIFF
--- a/core/src/main/java/me/athlaeos/valhallammo/commands/valhallasubcommands/HelpCommand.java
+++ b/core/src/main/java/me/athlaeos/valhallammo/commands/valhallasubcommands/HelpCommand.java
@@ -31,7 +31,7 @@ public class HelpCommand implements Command {
 		
 		if (pages.isEmpty()) return true;
 
-		int page = 0;
+		int page = 1;
 		if (args.length >= 2){
 			try {
 				page = Integer.parseInt(args[1]);
@@ -41,11 +41,12 @@ public class HelpCommand implements Command {
 			}
 		}
 
-		for (String line : pages.get(Math.max(0, Math.min(pages.size() - 1, page)))) {
+		page = Math.max(1, Math.min(pages.size(), page));
+		for (String line : pages.get(page - 1)) {
 			sender.sendMessage(Utils.chat(line));
 		}
 		Utils.chat("&8&m                                             ");
-		sender.sendMessage(Utils.chat(String.format("&8[&e1&8/&e%s&8]", pages.size())));
+		sender.sendMessage(Utils.chat(String.format("&8[&e%s&8/&e%s&8]", page, pages.size())));
 		return true;
 	}
 

--- a/core/src/main/resources/languages/en-us.json
+++ b/core/src/main/resources/languages/en-us.json
@@ -273,7 +273,7 @@
     "skilltree_arrow_name_nw": "&fMove up-left",
     "skilltree_perk_confirmation": "&fDo you want to unlock %perk%&f?",
     "warning_not_enough_skillpoints": "&cNot enough skill points",
-    "perk_format_requirement_one": "&7Requires:",
+    "perk_format_requirement_one": "&7Requires One Of:",
     "perk_format_requirement_all": "&7Requires:",
     "perk_format_requirement": "&7- %perk_required%",
     "perk_other_level_requirement": "&7            %skill% &7LV&e%level_required%",


### PR DESCRIPTION
Makes the default lang for `perk_format_requirement_one` be `&7Requires One Of:` instead of just `&7Requires:` as it's current form is unclear for players
Makes the `/val help <page>` command actually show what page is displayed instead of always 1. Also updates how the indexing is done (that way `/val help 1` shows the first page, not the second)