### PR TITLE
Fixed Repeated Damage After Hitting A Wall From Martial Arts

### DIFF
--- a/core/src/main/java/me/athlaeos/valhallammo/skills/skills/implementations/MartialArtsSkill.java
+++ b/core/src/main/java/me/athlaeos/valhallammo/skills/skills/implementations/MartialArtsSkill.java
@@ -52,11 +52,8 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerSwapHandItemsEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
-import org.bukkit.profile.PlayerProfile;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
@@ -251,7 +248,7 @@ public class MartialArtsSkill extends Skill implements Listener {
             ItemBuilder weapon = e.getDamager() instanceof Trident t && !ItemUtils.isEmpty(t.getItem()) ? new ItemBuilder(t.getItem()) : EntityCache.getAndCacheProperties(p).getMainHand();
             if (weapon != null && WeightClass.getWeightClass(weapon.getMeta()) != WeightClass.WEIGHTLESS) return;
             MartialArtsProfile profile = ProfileCache.getOrCache(p, MartialArtsProfile.class);
-
+            if (profile.getDropKickDamageType().stream().findFirst().orElse("ENTITY_HIT").equals(EntityUtils.getCustomDamageType(l))) return;
             double bonusDamage = 0;
             long timeSinceLastPunch = Timer.getTimerResult(p.getUniqueId(), "time_since_punch");
             int ticks = (int) Math.floor(timeSinceLastPunch / 50D);

--- a/core/src/main/java/me/athlaeos/valhallammo/utility/EntityUtils.java
+++ b/core/src/main/java/me/athlaeos/valhallammo/utility/EntityUtils.java
@@ -1,7 +1,6 @@
 package me.athlaeos.valhallammo.utility;
 
 import me.athlaeos.valhallammo.ValhallaMMO;
-import me.athlaeos.valhallammo.dom.Catch;
 import me.athlaeos.valhallammo.item.*;
 import me.athlaeos.valhallammo.playerstats.EntityProperties;
 import me.athlaeos.valhallammo.dom.BiFetcher;
@@ -23,6 +22,7 @@ import org.bukkit.entity.*;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
@@ -32,6 +32,7 @@ import java.lang.reflect.Method;
 import java.util.*;
 
 public class EntityUtils {
+    private static final String DAMAGE_CAUSE_KEY = "custom_damage_cause";
 
     public static int getTotalExperience(Player player) {
         return Math.round(player.getExp() * player.getExpToLevel()) + getTotalExperience(player.getLevel());
@@ -391,13 +392,20 @@ public class EntityUtils {
         int immunityBefore = entity.getNoDamageTicks();
         if (ignoreImmunity) entity.setNoDamageTicks(0);
         EntityDamagedListener.setCustomDamageCause(entity.getUniqueId(), type);
+        entity.setMetadata(DAMAGE_CAUSE_KEY, new FixedMetadataValue(ValhallaMMO.getInstance(), type));
         activeDamageProcesses.add(entity.getUniqueId());
         if (by != null) {
             EntityDamagedListener.setDamager(entity, by);
             entity.damage(amount, by);
         } else entity.damage(amount);
         activeDamageProcesses.remove(entity.getUniqueId());
+        entity.removeMetadata(DAMAGE_CAUSE_KEY, ValhallaMMO.getInstance());
         entity.setNoDamageTicks(immunityBefore);
+    }
+
+    public static String getCustomDamageType(LivingEntity entity){
+        if (!entity.hasMetadata(DAMAGE_CAUSE_KEY)) return null;
+        return entity.getMetadata(DAMAGE_CAUSE_KEY).getFirst().asString();
     }
 
     public static Entity getTrueDamager(EntityDamageByEntityEvent e){


### PR DESCRIPTION
# Description
By using the new EntityUtils changes I made, you can more easily determine the custom damage type, filter out "ENTITY_HIT," and prevent the runnable from being repeated after ending.

# Bug
Before this, it would constantly be damaged if it hit a wall until the timer ran out or if the entity died.