### PR TITLE
Enhanced MythicMobs hook.

### DIFF
--- a/core/src/main/java/me/athlaeos/valhallammo/entities/MonsterScalingManager.java
+++ b/core/src/main/java/me/athlaeos/valhallammo/entities/MonsterScalingManager.java
@@ -4,6 +4,7 @@ import me.athlaeos.valhallammo.ValhallaMMO;
 import me.athlaeos.valhallammo.configuration.ConfigManager;
 import me.athlaeos.valhallammo.dom.Catch;
 import me.athlaeos.valhallammo.event.EntityUpdateLevelEvent;
+import me.athlaeos.valhallammo.hooks.MythicMobsHook;
 import me.athlaeos.valhallammo.playerstats.AccumulativeStatManager;
 import me.athlaeos.valhallammo.playerstats.profiles.ProfileCache;
 import me.athlaeos.valhallammo.playerstats.profiles.implementations.PowerProfile;
@@ -162,6 +163,8 @@ public class MonsterScalingManager {
     public static double getStatValue(LivingEntity entity, String stat){
         if (!enabled || EntityClassification.matchesClassification(entity.getType(), EntityClassification.UNALIVE)) return 0;
         int level = Math.max(0, getLevel(entity));
+        if (MythicMobsHook.isMythicMob(entity))
+            return MythicMobsHook.getMythicMobStat(stat, entity);
         if (entityStatScaling.containsKey(entity.getType())){
             Map<String, String> entityStats = entityStatScaling.getOrDefault(entity.getType(), new HashMap<>());
             if (!entityStats.containsKey(stat)) return 0;

--- a/core/src/main/java/me/athlaeos/valhallammo/hooks/MythicMobsHook.java
+++ b/core/src/main/java/me/athlaeos/valhallammo/hooks/MythicMobsHook.java
@@ -1,13 +1,37 @@
 package me.athlaeos.valhallammo.hooks;
 
+import io.lumine.mythic.api.adapters.AbstractEntity;
+import io.lumine.mythic.api.config.MythicLineConfig;
 import io.lumine.mythic.api.mobs.entities.SpawnReason;
+import io.lumine.mythic.bukkit.BukkitAdapter;
+import io.lumine.mythic.bukkit.MythicBukkit;
+import io.lumine.mythic.bukkit.adapters.item.ItemComponentBukkitItemStack;
+import io.lumine.mythic.bukkit.events.MythicDamageEvent;
+import io.lumine.mythic.bukkit.events.MythicDropLoadEvent;
 import io.lumine.mythic.bukkit.events.MythicMobSpawnEvent;
+import io.lumine.mythic.bukkit.utils.numbers.RandomDouble;
+import io.lumine.mythic.core.drops.droppables.VanillaItemDrop;
+import io.lumine.mythic.core.mobs.ActiveMob;
+import io.lumine.mythic.core.skills.mechanics.DamageMechanic;
 import me.athlaeos.valhallammo.ValhallaMMO;
+import me.athlaeos.valhallammo.dom.CustomDamageType;
 import me.athlaeos.valhallammo.entities.MonsterScalingManager;
+import me.athlaeos.valhallammo.event.EntityUpdateLevelEvent;
+import me.athlaeos.valhallammo.item.CustomItemRegistry;
+import me.athlaeos.valhallammo.item.ItemAttributesRegistry;
+import me.athlaeos.valhallammo.listeners.EntityAttackListener;
+import me.athlaeos.valhallammo.listeners.EntityDamagedListener;
+import me.athlaeos.valhallammo.utility.EntityUtils;
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+
+import java.util.Arrays;
 
 public class MythicMobsHook extends PluginHook
 {
@@ -28,6 +52,22 @@ public class MythicMobsHook extends PluginHook
     {
         this.listener = new Listener()
         {
+            @EventHandler
+            public void mythicDropLoadEvent(MythicDropLoadEvent e)
+            {
+                if (!e.getDropName().equalsIgnoreCase("valhallammo") && !e.getDropName().equalsIgnoreCase("val"))
+                    return;
+
+                var split = e.getContainer().getLine().split(" ");
+                String itemName = split[1];
+                String amountRange = split.length > 2 ? split[2] : "1";
+                var item = CustomItemRegistry.getProcessedItem(itemName);
+                if (item == null)
+                    return;
+
+                e.register(new VanillaItemDrop(e.getContainer().getLine(), e.getConfig(), new ItemComponentBukkitItemStack(item), new RandomDouble(amountRange)));
+            }
+
             @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
             public void onMythicMobSpawn(MythicMobSpawnEvent event)
             {
@@ -42,8 +82,50 @@ public class MythicMobsHook extends PluginHook
                     event.setMobLevel(MonsterScalingManager.getAreaDifficultyLevel(event.getLocation(), null));
                 }
             }
+
+            @EventHandler
+            public void onLevelUp(EntityUpdateLevelEvent e)
+            {
+                var entity = e.getEntity();
+                var mob = MythicBukkit.inst().getMobManager().getActiveMob(entity.getUniqueId());
+                if (mob.isEmpty() || mob.get().getType().getFaction().equalsIgnoreCase("Animals"))
+                    return;
+
+                mob.get().setLevel(e.getLevel());
+            }
+            @EventHandler
+            public void onDamage(MythicDamageEvent e)
+            {
+                if (e.getTarget().getBukkitEntity() instanceof LivingEntity le)
+                {
+                    if (e.getDamageMetadata().getElement() != null)
+                        EntityDamagedListener.setCustomDamageCause(e.getTarget().getUniqueId(), e.getDamageMetadata().getElement());
+                }
+            }
         };
 
         Bukkit.getPluginManager().registerEvents(listener, ValhallaMMO.getInstance());
+    }
+
+    public static boolean isMythicMob(Entity entity)
+    {
+        if (!ValhallaMMO.isHookFunctional(MythicMobsHook.class))
+            return false;
+        return MythicBukkit.inst().getMobManager().isMythicMob(entity);
+    }
+
+    public static double getMythicMobStat(String stat, Entity entity)
+    {
+        stat = "VAL-" + stat;
+        if (!ValhallaMMO.isHookFunctional(MythicMobsHook.class))
+            return 0;
+        var inst = MythicBukkit.inst();
+        var mob = inst.getMobManager().getActiveMob(entity.getUniqueId());
+        if (mob.isEmpty())
+            return 0;
+        var pd = mob.get().getType().getStats().getOrDefault(stat, null);
+        if (pd == null)
+            return 0;
+        return pd.get(mob.get());
     }
 }


### PR DESCRIPTION
### BugFix
When EntittyUpdateLevelEvent is called, it now also updates the mythicmobs level of the entity

### Additions
#### Drops
MythicMobs now can drop ValhallaMMO items using this syntax: "valhallammo (item) (amount range)", valhallammo can also be replaced with "val", for example:
`val trinket_athena 1` mob will drop one of this trinket
`val trinket_athena 1to5` mob will drop 1 to 5 of this trinket
#### Stats
MythicMobs now can get valhallammo stats using this syntax: "VAL-(UPPERCASE_STAT_NAME) (amount)", for example:
`VAL-ARMOR_PENETRATION_FRACTION 1` will give the boss 100% armor penetration.
#### DamageType
The MythicMobs "damage" skill can now cause ValhallaMMO damage types using the "element" option, for example:
`damage{a=4;e=FREEZING; } @LivingInCone{a=30.0;r=2;rot=0.0;target=players}` will deal 4 freezing damage to all players in a 30deg angle in front of the entity executing this skill.