### PR TITLE
Remove duplicate impaling, fix blast prot not classified as defensive, missing mace enchant classification

### DIFF
--- a/core/src/main/java/me/athlaeos/valhallammo/item/EnchantmentClassification.java
+++ b/core/src/main/java/me/athlaeos/valhallammo/item/EnchantmentClassification.java
@@ -11,12 +11,12 @@ import java.util.HashSet;
 public enum EnchantmentClassification {
     OFFENSIVE("thorns", "bane_of_arthropods", "smite", "sharpness", "knockback", "fire_aspect",
             "impaling", "sweeping_edge", "channeling", "flame", "infinity", "loyalty", "multishot",
-            "piercing", "power", "punch", "quick_charge"),
+            "piercing", "power", "punch", "quick_charge", "density", "breach"),
     DEFENSIVE("projectile_protection", "feather_falling", "fire_protection", "blast_protection",
             "protection"),
     UTILITY("mending", "unbreaking", "aqua_affinity", "depth_strider", "frost_walker", "respiration",
             "soul_speed", "swift_sneak", "efficiency", "looting", "fortune", "riptide", "luck_of_the_sea", "lure",
-            "silk_touch"),
+            "silk_touch", "wind_burst"),
     CURSE("curse_of_vanishing", "curse_of_binding"),
     UNDEFINED;
     private final Collection<Enchantment> matches = new HashSet<>();


### PR DESCRIPTION
Was poking around enchanting logic for one of my own projects, and noticed a *possible* bug in the enchantment classification. Namely:
- Impaling's listed twice
- projectile_protection's listed twice
- blast protection isn't listed

Cross-ref'd with https://github.com/Athlaeos/ValhallaMMO/blob/master/core/src/main/resources/skills/enchanting.yml, seems there's a few other missing that were mace related: `breach`, `wind_burst` and `density`, so added those.