### PR TITLE
Fixed Martial Arts level up message saying "Unarmed"

### DIFF
--- a/core/src/main/resources/languages/en-us.json
+++ b/core/src/main/resources/languages/en-us.json
@@ -3624,8 +3624,8 @@
       "TITLE(&7You leveled up to &e%level%&7;&7Check &e/skills &7for available perks;40;5)"
     ],
     "skill-level-up-martial-arts": [
-      "TITLE(&r;&aUnarmed&7 leveled up to &a%level%)",
-      "&aUnarmed&7 leveled up to &a%level%"
+      "TITLE(&r;&aMartial Arts&7 leveled up to &a%level%)",
+      "&aMartial Arts&7 leveled up to &a%level%"
     ],
     "skill-level-up-trading": [
       "TITLE(&r;&aTrading&7 leveled up to &a%level%)",


### PR DESCRIPTION
From the looks of it, Martial Arts used to be named "Unarmed", and this PR just fixes the level up message still saying the old name.

I left "Unarmed Damage" alone because as a damage type, "unarmed" still makes sense.

