### PR TITLE
Add support for icon_data on perk icons

### DIFF
--- a/core/src/main/java/me/athlaeos/valhallammo/skills/skills/Skill.java
+++ b/core/src/main/java/me/athlaeos/valhallammo/skills/skills/Skill.java
@@ -239,6 +239,15 @@ public abstract class Skill {
                 ItemStack icon = ItemUtils.getIconFromConfig(progressionConfig, "perks." + perkName + ".icon", getClass().getSimpleName() + " progression config", new ItemStack(Material.PAPER));
                 String permission = progressionConfig.getString("perks." + perkName + ".permission");
 
+                int perkModelData = progressionConfig.getInt("perks." + perkName + ".icon_data", -1);
+                if (perkModelData >= 0) {
+                    ItemMeta iconMeta = ItemUtils.getItemMeta(icon);
+                    if (iconMeta != null) {
+                        iconMeta.setCustomModelData(perkModelData);
+                        ItemUtils.setMetaNoClone(icon, iconMeta);
+                    }
+                }
+
                 int[] c = parseCoordinates(progressionConfig.getString("perks." + perkName + ".coords", "0,0"));
                 int perkX = c[0];
                 int perkY = c[1];


### PR DESCRIPTION
The adds support for custom model data on perk icons, using a config like this:

```
  missile:
    icon: PRISMARINE_SHARD
    icon_data: 18001
    name: Magic Missile
```

Unfortunately I couldn't test this myself, I tried to get the project building but had some missing dependencies from various Paper versions. (I can relate to what a mess backwards compatibility can be!)