### PR TITLE
Convenient single-item string list perk parameters

### DIFF
--- a/core/src/main/java/me/athlaeos/valhallammo/skills/perk_rewards/PerkReward.java
+++ b/core/src/main/java/me/athlaeos/valhallammo/skills/perk_rewards/PerkReward.java
@@ -83,6 +83,7 @@ public abstract class PerkReward implements Cloneable{
 
     @SuppressWarnings("unchecked")
     protected List<String> parseStringList(Object o){
+        if (o instanceof String) return List.of((String) o);
         if (o instanceof List<?>) return (List<String>) o;
         throw new IllegalArgumentException("Invalid argument type for perk reward " + getClass().getSimpleName() + ", expected a string list, but was " + o.getClass().getSimpleName());
     }


### PR DESCRIPTION
Allow using single strings in perk reward configurations that expect string lists

Not sure if this is a great idea since it won't work with the perk reward command, but it's a simple change that adds a little convenience.

Feel free to close and ignore this if you don't like it :)