### PR TITLE
Categorize ValhallaMMO grid recipes in the vanilla recipe book

### DIFF
--- a/core/src/main/java/me/athlaeos/valhallammo/crafting/recipetypes/DynamicGridRecipe.java
+++ b/core/src/main/java/me/athlaeos/valhallammo/crafting/recipetypes/DynamicGridRecipe.java
@@ -3,6 +3,7 @@ package me.athlaeos.valhallammo.crafting.recipetypes;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import me.athlaeos.valhallammo.ValhallaMMO;
+import me.athlaeos.valhallammo.dom.MinecraftVersion;
 import me.athlaeos.valhallammo.crafting.ToolRequirement;
 import me.athlaeos.valhallammo.crafting.ToolRequirementType;
 import me.athlaeos.valhallammo.crafting.dynamicitemmodifiers.DynamicItemModifier;
@@ -127,6 +128,7 @@ public class DynamicGridRecipe implements ValhallaRecipe, ValhallaKeyedRecipe {
             recipe.addIngredient(choice);
         }
 
+        applyBookCategory(recipe);
         return recipe;
     }
 
@@ -145,7 +147,26 @@ public class DynamicGridRecipe implements ValhallaRecipe, ValhallaKeyedRecipe {
             recipe.setIngredient(ci, choice);
         }
 
+        applyBookCategory(recipe);
         return recipe;
+    }
+
+    /**
+     * Assigns the vanilla recipe-book category (Equipment / Building / Redstone / Misc) based on the recipe's result,
+     * so ValhallaMMO weapons, tools and armor show up under the correct tab instead of all landing in "Misc".
+     * <p>
+     * The actual work lives in {@link RecipeBookCategorizer}, which references the 1.19.3+ {@code CraftingBookCategory}
+     * API. The version check here guards that call, and because {@code RecipeBookCategorizer} is a separate class it is
+     * only loaded on servers that pass the check — so older servers (1.19 - 1.19.2) never touch the missing API.
+     */
+    private void applyBookCategory(ShapedRecipe recipe){
+        if (!MinecraftVersion.currentVersionNewerThan(MinecraftVersion.MINECRAFT_1_19_3)) return;
+        RecipeBookCategorizer.apply(recipe);
+    }
+
+    private void applyBookCategory(ShapelessRecipe recipe){
+        if (!MinecraftVersion.currentVersionNewerThan(MinecraftVersion.MINECRAFT_1_19_3)) return;
+        RecipeBookCategorizer.apply(recipe);
     }
 
     private ItemStack recipeBookIcon(ItemStack i){

--- a/core/src/main/java/me/athlaeos/valhallammo/crafting/recipetypes/RecipeBookCategorizer.java
+++ b/core/src/main/java/me/athlaeos/valhallammo/crafting/recipetypes/RecipeBookCategorizer.java
@@ -1,0 +1,57 @@
+package me.athlaeos.valhallammo.crafting.recipetypes;
+
+import me.athlaeos.valhallammo.item.EquipmentClass;
+import me.athlaeos.valhallammo.utility.ItemUtils;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.ShapelessRecipe;
+import org.bukkit.inventory.recipe.CraftingBookCategory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Assigns the vanilla recipe-book category (Equipment / Building / Redstone / Misc) to ValhallaMMO recipes based on
+ * their result, so weapons, tools and armor show up under the correct tab instead of all landing in "Misc".
+ * <p>
+ * IMPORTANT: this class references {@link CraftingBookCategory}, which only exists on Minecraft 1.19.3+. It is
+ * deliberately kept in its own class so the JVM never has to load it on older servers. Callers MUST gate every
+ * reference to this class behind a version check (see callers in {@code DynamicGridRecipe}); because the class is only
+ * loaded the first time one of its methods is invoked, an older server that never passes the version check will never
+ * trigger class verification/resolution here, avoiding a {@code NoClassDefFoundError}.
+ */
+public final class RecipeBookCategorizer {
+
+    private RecipeBookCategorizer(){}
+
+    // Redstone has no single Bukkit property that identifies it, so it stays an explicit set.
+    // Built through ItemUtils.getMaterialSet so unknown names on older versions are silently skipped.
+    private static final Set<Material> REDSTONE_ITEMS = new HashSet<>(ItemUtils.getMaterialSet(
+            "REDSTONE", "REDSTONE_BLOCK", "REDSTONE_TORCH", "REDSTONE_LAMP", "REPEATER", "COMPARATOR",
+            "PISTON", "STICKY_PISTON", "OBSERVER", "HOPPER", "DROPPER", "DISPENSER", "LEVER", "TARGET",
+            "DAYLIGHT_DETECTOR", "TRIPWIRE_HOOK", "NOTE_BLOCK"));
+
+    public static void apply(ShapedRecipe recipe){
+        recipe.setCategory(categoryFor(recipe.getResult()));
+    }
+
+    public static void apply(ShapelessRecipe recipe){
+        recipe.setCategory(categoryFor(recipe.getResult()));
+    }
+
+    private static CraftingBookCategory categoryFor(ItemStack item){
+        if (ItemUtils.isEmpty(item)) return CraftingBookCategory.MISC;
+        Material type = item.getType();
+        // Weapons, tools and armor: EquipmentClass already maps every vanilla + ValhallaMMO equipment
+        // material, so we reuse it instead of pattern-matching material names by hand.
+        if (EquipmentClass.getMatchingClass(type) != null) return CraftingBookCategory.EQUIPMENT;
+        // Redstone components (curated set, see above).
+        if (REDSTONE_ITEMS.contains(type) || type.name().endsWith("_BUTTON") ||
+                type.name().endsWith("_PRESSURE_PLATE") || type.name().endsWith("_RAIL"))
+            return CraftingBookCategory.REDSTONE;
+        // Anything else that's a placeable block goes under Building Blocks.
+        if (type.isBlock()) return CraftingBookCategory.BUILDING;
+        return CraftingBookCategory.MISC;
+    }
+}


### PR DESCRIPTION
Custom grid recipes previously all landed under the "Misc" tab of the recipe book. Assign the proper CraftingBookCategory (Equipment / Building / Redstone / Misc) based on the recipe result so weapons, tools and armor show up under the correct tab.

Equipment detection reuses the existing EquipmentClass mapping (which already covers vanilla + ValhallaMMO custom equipment materials) instead of matching material names by hand.

CraftingBookCategory only exists on MC 1.19.3+, so all usage is isolated in a dedicated RecipeBookCategorizer class that is only referenced after a version check. Because the class is loaded lazily, servers on 1.19 - 1.19.2 (still supported via api-version 1.19) never load the missing API and cannot hit a NoClassDefFoundError.