### PR TITLE
Make recipe-book category an editable recipe property

### DIFF
--- a/core/src/main/java/me/athlaeos/valhallammo/crafting/recipetypes/DynamicGridRecipe.java
+++ b/core/src/main/java/me/athlaeos/valhallammo/crafting/recipetypes/DynamicGridRecipe.java
@@ -3,7 +3,6 @@ package me.athlaeos.valhallammo.crafting.recipetypes;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import me.athlaeos.valhallammo.ValhallaMMO;
-import me.athlaeos.valhallammo.dom.MinecraftVersion;
 import me.athlaeos.valhallammo.crafting.ToolRequirement;
 import me.athlaeos.valhallammo.crafting.ToolRequirementType;
 import me.athlaeos.valhallammo.crafting.dynamicitemmodifiers.DynamicItemModifier;
@@ -53,6 +52,7 @@ public class DynamicGridRecipe implements ValhallaRecipe, ValhallaKeyedRecipe {
     private boolean unlockedForEveryone = false;
     private ToolRequirement toolRequirement = new ToolRequirement(ToolRequirementType.NOT_REQUIRED, -1);
     private Collection<String> validations = new HashSet<>();
+    private String bookCategory = null; // explicit recipe-book category; null means "automatic" (see RecipeBookCategorizer)
 
     public DynamicGridRecipe(String name){
         this.name = name;
@@ -114,6 +114,14 @@ public class DynamicGridRecipe implements ValhallaRecipe, ValhallaKeyedRecipe {
     public void setValidations(Collection<String> validations) {this.validations = validations;}
     public boolean isHiddenFromBook() { return hiddenFromBook; }
 
+    /** @return the explicitly configured recipe-book category, or null if it should be auto-detected. */
+    public String getBookCategory() { return bookCategory; }
+    public void setBookCategory(String bookCategory) { this.bookCategory = bookCategory; }
+    /** @return the category to actually apply: the explicit one if set, otherwise the auto-detected default. */
+    public String getEffectiveBookCategory() {
+        return bookCategory != null ? bookCategory : RecipeBookCategorizer.defaultCategoryFor(result);
+    }
+
     public ShapelessRecipe getShapelessRecipe(){
         if (!shapeless || this.items.isEmpty()) return null;
         ShapelessRecipe recipe = new ShapelessRecipe(shapelessKey, recipeBookIcon(tinker ? getGridTinkerEquipment().getItem() : result));
@@ -128,7 +136,7 @@ public class DynamicGridRecipe implements ValhallaRecipe, ValhallaKeyedRecipe {
             recipe.addIngredient(choice);
         }
 
-        applyBookCategory(recipe);
+        if (ValhallaMMO.getNms() != null) ValhallaMMO.getNms().applyRecipeBookCategory(recipe, getEffectiveBookCategory());
         return recipe;
     }
 
@@ -147,26 +155,8 @@ public class DynamicGridRecipe implements ValhallaRecipe, ValhallaKeyedRecipe {
             recipe.setIngredient(ci, choice);
         }
 
-        applyBookCategory(recipe);
+        if (ValhallaMMO.getNms() != null) ValhallaMMO.getNms().applyRecipeBookCategory(recipe, getEffectiveBookCategory());
         return recipe;
-    }
-
-    /**
-     * Assigns the vanilla recipe-book category (Equipment / Building / Redstone / Misc) based on the recipe's result,
-     * so ValhallaMMO weapons, tools and armor show up under the correct tab instead of all landing in "Misc".
-     * <p>
-     * The actual work lives in {@link RecipeBookCategorizer}, which references the 1.19.3+ {@code CraftingBookCategory}
-     * API. The version check here guards that call, and because {@code RecipeBookCategorizer} is a separate class it is
-     * only loaded on servers that pass the check — so older servers (1.19 - 1.19.2) never touch the missing API.
-     */
-    private void applyBookCategory(ShapedRecipe recipe){
-        if (!MinecraftVersion.currentVersionNewerThan(MinecraftVersion.MINECRAFT_1_19_3)) return;
-        RecipeBookCategorizer.apply(recipe);
-    }
-
-    private void applyBookCategory(ShapelessRecipe recipe){
-        if (!MinecraftVersion.currentVersionNewerThan(MinecraftVersion.MINECRAFT_1_19_3)) return;
-        RecipeBookCategorizer.apply(recipe);
     }
 
     private ItemStack recipeBookIcon(ItemStack i){

--- a/core/src/main/java/me/athlaeos/valhallammo/crafting/recipetypes/RecipeBookCategorizer.java
+++ b/core/src/main/java/me/athlaeos/valhallammo/crafting/recipetypes/RecipeBookCategorizer.java
@@ -4,26 +4,33 @@ import me.athlaeos.valhallammo.item.EquipmentClass;
 import me.athlaeos.valhallammo.utility.ItemUtils;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.ShapedRecipe;
-import org.bukkit.inventory.ShapelessRecipe;
-import org.bukkit.inventory.recipe.CraftingBookCategory;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
- * Assigns the vanilla recipe-book category (Equipment / Building / Redstone / Misc) to ValhallaMMO recipes based on
- * their result, so weapons, tools and armor show up under the correct tab instead of all landing in "Misc".
+ * Version-safe resolver for the default recipe-book category of a grid recipe.
  * <p>
- * IMPORTANT: this class references {@link CraftingBookCategory}, which only exists on Minecraft 1.19.3+. It is
- * deliberately kept in its own class so the JVM never has to load it on older servers. Callers MUST gate every
- * reference to this class behind a version check (see callers in {@code DynamicGridRecipe}); because the class is only
- * loaded the first time one of its methods is invoked, an older server that never passes the version check will never
- * trigger class verification/resolution here, avoiding a {@code NoClassDefFoundError}.
+ * It returns the category name as a plain {@link String} ("EQUIPMENT" / "BUILDING" / "REDSTONE" / "MISC"), so this class
+ * never references the 1.19.3+ {@code CraftingBookCategory} API and is safe to load on any supported version. The actual
+ * assignment to the Bukkit recipe (which does need that API) lives in the NMS layer
+ * ({@code NMS#applyRecipeBookCategory}), which is overridden as a no-op on the 1.19 - 1.19.2 module.
+ * <p>
+ * This is used purely as a <i>default</i>: a recipe may store an explicit category, and only falls back here when none
+ * is set (see {@code DynamicGridRecipe#getEffectiveBookCategory()}).
  */
 public final class RecipeBookCategorizer {
 
     private RecipeBookCategorizer(){}
+
+    public static final String EQUIPMENT = "EQUIPMENT";
+    public static final String BUILDING = "BUILDING";
+    public static final String REDSTONE = "REDSTONE";
+    public static final String MISC = "MISC";
+
+    /** Selectable explicit categories, in cycle order. "Automatic" is represented by a null category on the recipe. */
+    public static final List<String> CATEGORIES = List.of(EQUIPMENT, BUILDING, REDSTONE, MISC);
 
     // Redstone has no single Bukkit property that identifies it, so it stays an explicit set.
     // Built through ItemUtils.getMaterialSet so unknown names on older versions are silently skipped.
@@ -32,26 +39,23 @@ public final class RecipeBookCategorizer {
             "PISTON", "STICKY_PISTON", "OBSERVER", "HOPPER", "DROPPER", "DISPENSER", "LEVER", "TARGET",
             "DAYLIGHT_DETECTOR", "TRIPWIRE_HOOK", "NOTE_BLOCK"));
 
-    public static void apply(ShapedRecipe recipe){
-        recipe.setCategory(categoryFor(recipe.getResult()));
-    }
-
-    public static void apply(ShapelessRecipe recipe){
-        recipe.setCategory(categoryFor(recipe.getResult()));
-    }
-
-    private static CraftingBookCategory categoryFor(ItemStack item){
-        if (ItemUtils.isEmpty(item)) return CraftingBookCategory.MISC;
+    /**
+     * Auto-detects the most fitting category for a recipe result, used when a recipe has no explicit category.
+     * @param item the recipe result
+     * @return one of {@link #EQUIPMENT}, {@link #BUILDING}, {@link #REDSTONE} or {@link #MISC}
+     */
+    public static String defaultCategoryFor(ItemStack item){
+        if (ItemUtils.isEmpty(item)) return MISC;
         Material type = item.getType();
         // Weapons, tools and armor: EquipmentClass already maps every vanilla + ValhallaMMO equipment
         // material, so we reuse it instead of pattern-matching material names by hand.
-        if (EquipmentClass.getMatchingClass(type) != null) return CraftingBookCategory.EQUIPMENT;
+        if (EquipmentClass.getMatchingClass(type) != null) return EQUIPMENT;
         // Redstone components (curated set, see above).
         if (REDSTONE_ITEMS.contains(type) || type.name().endsWith("_BUTTON") ||
                 type.name().endsWith("_PRESSURE_PLATE") || type.name().endsWith("_RAIL"))
-            return CraftingBookCategory.REDSTONE;
+            return REDSTONE;
         // Anything else that's a placeable block goes under Building Blocks.
-        if (type.isBlock()) return CraftingBookCategory.BUILDING;
-        return CraftingBookCategory.MISC;
+        if (type.isBlock()) return BUILDING;
+        return MISC;
     }
 }

--- a/core/src/main/java/me/athlaeos/valhallammo/gui/implementations/GridRecipeEditor.java
+++ b/core/src/main/java/me/athlaeos/valhallammo/gui/implementations/GridRecipeEditor.java
@@ -12,6 +12,7 @@ import me.athlaeos.valhallammo.crafting.ingredientconfiguration.RecipeOption;
 import me.athlaeos.valhallammo.crafting.ingredientconfiguration.SlotEntry;
 import me.athlaeos.valhallammo.crafting.ingredientconfiguration.implementations.MaterialChoice;
 import me.athlaeos.valhallammo.crafting.recipetypes.DynamicGridRecipe;
+import me.athlaeos.valhallammo.crafting.recipetypes.RecipeBookCategorizer;
 import me.athlaeos.valhallammo.dom.Action;
 import me.athlaeos.valhallammo.dom.Question;
 import me.athlaeos.valhallammo.dom.Questionnaire;
@@ -58,6 +59,7 @@ public class GridRecipeEditor extends Menu implements SetModifiersMenu, SetRecip
     private Collection<String> validations;
     private String displayName;
     private String description;
+    private String bookCategory; // null = automatic
 
     private static final ItemStack toggleValhallaToolRequirementButton = new ItemBuilder(getButtonData("editor_recipe_grid_valhallatoolrequirement", Material.DIAMOND_PICKAXE))
             .name("&eValhalla Tools")
@@ -85,6 +87,15 @@ public class GridRecipeEditor extends Menu implements SetModifiersMenu, SetRecip
             .lore("&7If enabled, the recipe will",
                     "&7not be visible in the recipe book.",
                     "&eClick to toggle on/off")
+            .flag(ItemFlag.HIDE_ATTRIBUTES).wipeAttributes().get();
+    private static final ItemStack setBookCategoryButton = new ItemBuilder(getButtonData("editor_recipe_grid_setbookcategory", Material.KNOWLEDGE_BOOK))
+            .name("&eRecipe Book Category")
+            .stringTag(BUTTON_ACTION_KEY, "setBookCategoryButton")
+            .lore("&7Which tab this recipe appears under",
+                    "&7in the vanilla recipe book.",
+                    "&7&oAutomatic&7 picks a tab based on the result",
+                    "&7(equipment/building/redstone/misc).",
+                    "&eLeft-click to cycle, right-click for Automatic")
             .flag(ItemFlag.HIDE_ATTRIBUTES).wipeAttributes().get();
     private static final ItemStack selectTinkerItemButton = new ItemBuilder(getButtonData("editor_recipe_grid_selecttinkeritem", Material.ANVIL))
             .name("&eSelect which tool to tinker")
@@ -234,6 +245,7 @@ public class GridRecipeEditor extends Menu implements SetModifiersMenu, SetRecip
         this.displayName = recipe.getDisplayName();
         this.description = recipe.getDescription();
         this.hidden = recipe.isHiddenFromBook();
+        this.bookCategory = recipe.getBookCategory();
     }
 
     public GridRecipeEditor(PlayerMenuUtility playerMenuUtility, DynamicGridRecipe recipe, String newName) {
@@ -255,6 +267,7 @@ public class GridRecipeEditor extends Menu implements SetModifiersMenu, SetRecip
         this.displayName = recipe.getDisplayName();
         this.description = recipe.getDescription();
         this.hidden = recipe.isHiddenFromBook();
+        this.bookCategory = recipe.getBookCategory();
 
         this.recipe.setItems(items);
         this.recipe.setResult(result);
@@ -270,6 +283,7 @@ public class GridRecipeEditor extends Menu implements SetModifiersMenu, SetRecip
         this.recipe.setDescription(description);
         this.recipe.setDisplayName(displayName);
         this.recipe.setHiddenFromBook(hidden);
+        this.recipe.setBookCategory(bookCategory);
     }
 
     @Override
@@ -395,6 +409,7 @@ public class GridRecipeEditor extends Menu implements SetModifiersMenu, SetRecip
                     recipe.setDescription(description);
                     recipe.setDisplayName(displayName);
                     recipe.setHiddenFromBook(hidden);
+                    recipe.setBookCategory(bookCategory);
 
                     CustomRecipeRegistry.register(recipe, true);
                     CustomRecipeRegistry.setChangesMade();
@@ -428,6 +443,7 @@ public class GridRecipeEditor extends Menu implements SetModifiersMenu, SetRecip
                 case "toggleTinkerButton" -> tinker = !tinker;
                 case "toggleShapelessButton" -> shapeless = !shapeless;
                 case "toggleUnlockedForEveryoneButton" -> unlockedForEveryone = !unlockedForEveryone;
+                case "setBookCategoryButton" -> bookCategory = cycleBookCategory(bookCategory, e.getClick().isRightClick());
                 case "selectTinkerItemButton", "selectToolItemButton" -> e.setCancelled(false);
             }
         }
@@ -502,6 +518,31 @@ public class GridRecipeEditor extends Menu implements SetModifiersMenu, SetRecip
                     items.put(index, new SlotEntry(new ItemBuilder(e.getCursor().clone()).amount(1).get(), new MaterialChoice()));
             }
         }
+    }
+
+    /**
+     * Cycles the recipe-book category. Forward order: Automatic (null) -&gt; EQUIPMENT -&gt; BUILDING -&gt; REDSTONE -&gt; MISC -&gt; Automatic.
+     * @param current the current value, null meaning automatic
+     * @param toAutomatic if true, jumps straight back to Automatic (right-click shortcut)
+     * @return the next category, or null for automatic
+     */
+    private static String cycleBookCategory(String current, boolean toAutomatic){
+        if (toAutomatic) return null;
+        List<String> categories = RecipeBookCategorizer.CATEGORIES;
+        if (current == null) return categories.get(0);
+        int i = categories.indexOf(current);
+        if (i < 0 || i >= categories.size() - 1) return null; // unknown or last entry -> back to automatic
+        return categories.get(i + 1);
+    }
+
+    private String bookCategoryLabel(){
+        if (bookCategory == null) return "&fAutomatic &7(" + prettyCategory(RecipeBookCategorizer.defaultCategoryFor(result)) + ")";
+        return "&a" + prettyCategory(bookCategory);
+    }
+
+    private static String prettyCategory(String category){
+        if (category == null || category.isEmpty()) return String.valueOf(category);
+        return category.charAt(0) + category.substring(1).toLowerCase(Locale.ROOT);
     }
 
     @SuppressWarnings("all")
@@ -604,6 +645,7 @@ public class GridRecipeEditor extends Menu implements SetModifiersMenu, SetRecip
         inventory.setItem(1, new ItemBuilder(setDescriptionButton).lore(ItemUtils.setListPlaceholder(ItemUtils.getLore(setDescriptionButton), "%description%", description)).get());
         inventory.setItem(3, new ItemBuilder(selectValidationButton).lore(ItemUtils.setListPlaceholder(ItemUtils.getLore(selectValidationButton), "%description%", validationLore)).get());
         inventory.setItem(5, new ItemBuilder(toggleUnlockedForEveryoneButton).name("&eUnlocked for Everyone " + (unlockedForEveryone ? "&aYes" : "&fNo")).get());
+        inventory.setItem(7, new ItemBuilder(setBookCategoryButton).name("&eRecipe Book Category: " + bookCategoryLabel()).get());
         inventory.setItem(8, new ItemBuilder(toggleHiddenButton).name("&eHidden from Recipe Book: " + (hidden ? "&aYes" : "&fNo")).get());
         inventory.setItem(9, selectTinkerItemButton);
         inventory.setItem(17, new ItemBuilder(toggleValhallaToolRequirementButton).name("&eValhalla Tools: " + (requireValhallaTools ? "&aYes" : "&fNo")).get());

--- a/core/src/main/java/me/athlaeos/valhallammo/nms/NMS.java
+++ b/core/src/main/java/me/athlaeos/valhallammo/nms/NMS.java
@@ -25,8 +25,11 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.ShapelessRecipe;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.inventory.recipe.CraftingBookCategory;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.potion.PotionType;
 
@@ -122,5 +125,32 @@ public interface NMS extends Listener {
     }
     default String getDamageTypeFromEvent(EntityDamageEvent e){
         return e.getCause().toString();
+    }
+
+    /**
+     * Assigns the vanilla recipe-book category (Equipment / Building / Redstone / Misc) to a shaped recipe.
+     * <p>
+     * The {@link CraftingBookCategory} API only exists on Minecraft 1.19.3+, so this default implementation is
+     * overridden as a no-op on the 1.19 - 1.19.2 module ({@code NMS_v1_19_R1}). Defining the behaviour here, rather than
+     * behind a runtime version check, lets each version decide via override.
+     * @param recipe the recipe to categorise
+     * @param category the category name ("EQUIPMENT" / "BUILDING" / "REDSTONE" / "MISC"); unknown values fall back to MISC
+     */
+    default void applyRecipeBookCategory(ShapedRecipe recipe, String category){
+        recipe.setCategory(parseCraftingBookCategory(category));
+    }
+
+    /** @see #applyRecipeBookCategory(ShapedRecipe, String) */
+    default void applyRecipeBookCategory(ShapelessRecipe recipe, String category){
+        recipe.setCategory(parseCraftingBookCategory(category));
+    }
+
+    private static CraftingBookCategory parseCraftingBookCategory(String category){
+        if (category == null) return CraftingBookCategory.MISC;
+        try {
+            return CraftingBookCategory.valueOf(category);
+        } catch (IllegalArgumentException e){
+            return CraftingBookCategory.MISC;
+        }
     }
 }

--- a/core/src/main/resources/gui_details.yml
+++ b/core/src/main/resources/gui_details.yml
@@ -33,6 +33,7 @@ editor_recipe_grid_settoolrequirement: PAPER:1829131
 editor_recipe_grid_setdisplayname: NAME_TAG:-1
 editor_recipe_grid_setdescription: WRITABLE_BOOK:-1
 editor_recipe_grid_togglehidden: REDSTONE_LAMP:-1
+editor_recipe_grid_setbookcategory: KNOWLEDGE_BOOK:-1
 
 editor_recipe_cooking_valhallatoolrequirement: DIAMOND_PICKAXE:1829130
 editor_recipe_cooking_toggletinker: ANVIL:1829130

--- a/v1_19_R1/src/main/java/me/athlaeos/valhallammo/nms/NMS_v1_19_R1.java
+++ b/v1_19_R1/src/main/java/me/athlaeos/valhallammo/nms/NMS_v1_19_R1.java
@@ -43,6 +43,8 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.ShapelessRecipe;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionData;
@@ -434,5 +436,16 @@ public final class NMS_v1_19_R1 implements NMS {
     public String getToolTipStyle(ItemMeta meta) {
         // not compatible
         return null;
+    }
+
+    // The CraftingBookCategory API does not exist on 1.19 - 1.19.2, so recipe-book categories are a no-op here.
+    @Override
+    public void applyRecipeBookCategory(ShapedRecipe recipe, String category) {
+        // not compatible
+    }
+
+    @Override
+    public void applyRecipeBookCategory(ShapelessRecipe recipe, String category) {
+        // not compatible
     }
 }


### PR DESCRIPTION
Follow-up to the recipe-book categorization PR, addressing the review feedback.

- DynamicGridRecipe now stores an optional bookCategory property (serialized via Gson). When unset (null) it falls back to the auto-detection, which now acts purely as a default value getter (RecipeBookCategorizer.defaultCategoryFor). Existing recipes without the property keep working retroactively.
- Add a "Recipe Book Category" button to the grid recipe editor to set it manually (cycles Automatic / Equipment / Building / Redstone / Misc; right-click resets to Automatic).
- Apply the category through the NMS layer instead of a runtime version check: NMS#applyRecipeBookCategory is a default method overridden as a no-op on the 1.19 - 1.19.2 module (NMS_v1_19_R1), so the 1.19.3+ CraftingBookCategory API is never referenced on older versions.
- RecipeBookCategorizer is now String-based and version-safe (no longer references CraftingBookCategory), so it can resolve defaults on any version.

<img width="1754" height="1004" alt="image" src="https://github.com/user-attachments/assets/db5818c9-3e4b-4cce-96a6-ca2753e1c82e" />
